### PR TITLE
feat: store actions per street and add showdown_details

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ This is a complete No-Limit Texas Hold'em tournament simulator designed for AI b
 
 | Method | Purpose |
 |--------|---------|
-| `simulate_hand()` | Orchestrates a complete hand from deal to showdown |
+| `simulate_hand()` | Orchestrates a complete hand from deal to showdown; returns dict with `winners`, `eliminated`, `total_pot`, `ended_early`, `showdown` (bool), `final_street`, and when showdown is True, `showdown_details` (dict with `players` and `hands`) |
 | `run_betting_round(street)` | Executes betting logic for a single street |
 | `_reconcile_bets_to_pots()` | Creates side pots for all-in scenarios |
 | `end_hand()` | Evaluates hands and distributes winnings |
@@ -65,7 +65,7 @@ This is a complete No-Limit Texas Hold'em tournament simulator designed for AI b
 - `pots`: List of Pot objects (index 0 = main pot, 1+ = side pots)
 - `total_pot`: Aggregate chip total across all pots
 - `blinds_schedule`: Dict mapping round number to (SB, BB)
-- `current_hand_history`: Actions by street
+- `current_hand_history`: Per-street action history (Dict[str, StreetHistory]; each street has `community_cards` and `actions`)
 - `hand_contributions`: Cumulative bets per player for pot calculation
 
 **Betting Round Algorithm:**
@@ -136,8 +136,8 @@ def get_action(
 | `blinds` | Tuple[int, int] | Current (small_blind, big_blind) |
 | `blinds_schedule` | Dict[int, Tuple[int, int]] | Future blind levels |
 | `minimum_raise_amount` | int | Minimum valid raise size |
-| `current_hand_history` | Dict[str, List[Action]] | Actions by street |
-| `previous_hand_histories` | List[Dict[...]] | Past hand histories |
+| `current_hand_history` | Dict[str, StreetHistory] | Per-street history: each value has `community_cards` and `actions` |
+| `previous_hand_histories` | List[Dict[str, StreetHistory]] | Past hand histories (same shape) |
 
 **Utility Methods:**
 - `get_current_street()`: Returns 'preflop', 'flop', 'turn', or 'river'
@@ -536,7 +536,7 @@ Players implement the `Player` interface, allowing different bot strategies to b
 - **Antes:** Modify `collect_blinds()` to collect antes
 - **Different Poker Variants:** Extend `HandJudge` with new hand rankings
 - **Tournament Payouts:** Add payout structure to Table
-- **Hand Logging:** Extend `current_hand_history` tracking
+- **Hand Logging:** Hand history is already per-street (`StreetHistory` with `community_cards` and `actions`); extend as needed
 - **Real-time Visualization:** Hook into betting round callbacks
 
 ## File Structure

--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ def get_action(self, gamestate: PublicGamestate, hole_cards: Tuple[str, str]) ->
         print(f"Player {i}: Stack={player_info.stack}, Bet={player_info.current_bet}, "
               f"Active={player_info.active}, All-in={player_info.is_all_in}")
 
-    # Betting history
-    preflop_actions = gamestate.current_hand_history['preflop']
-    # Each action is an Action(player_index, action_type, amount)
+    # Betting history (each street is a StreetHistory with .community_cards and .actions)
+    preflop_street = gamestate.current_hand_history['preflop']
+    preflop_actions = preflop_street.actions  # list of Action(player_index, action_type, amount)
+    # preflop_street.community_cards is [] for preflop; flop/turn/river have the board at that street
 ```
 
 ### Step 3: Implement Simple Strategy
@@ -314,15 +315,16 @@ for pot in gamestate.pots:
 ### Betting History
 
 ```python
-# Actions in current hand
+# Each street is a StreetHistory with .community_cards and .actions
 preflop = gamestate.current_hand_history['preflop']
 flop = gamestate.current_hand_history['flop']
 turn = gamestate.current_hand_history['turn']
 river = gamestate.current_hand_history['river']
 
-# Each action is an Action object
-for action in preflop:
+# Iterate over actions; each action is an Action object
+for action in preflop.actions:
     print(f"Player {action.player_index} did {action.action_type} for {action.amount}")
+# Board at that street: preflop.community_cards ([]), flop.community_cards (3 cards), etc.
 ```
 
 ### Utility Methods
@@ -665,6 +667,7 @@ while sum(1 for p in table.player_public_infos if not p.busted) > 1:
         for player_idx in result['eliminated']:
             print(f"ELIMINATED: Player {player_idx}")
 
+    # When result['showdown'] is True, result['showdown_details'] has 'players' and 'hands' (player_idx -> hand name)
     hand_num += 1
 
 # Final standings

--- a/examples/simple_game.py
+++ b/examples/simple_game.py
@@ -74,14 +74,23 @@ def main():
         if result['showdown']:
             print("\n--- SHOWDOWN ---")
             print("\nActive players at showdown:")
-            for winner_idx in result['winners'].keys():
+            details = result.get('showdown_details')
+            if details and 'hands' in details:
+                for idx in details.get('players', []):
+                    hole = table.player_hole_cards[idx]
+                    hand_name = details['hands'].get(idx, '?')
+                    hand_display = hand_name.replace('_', ' ').title() if hand_name != '?' else '?'
+                    print(f"  Player {idx} ({table.players[idx].__class__.__name__}): "
+                          f"{hole} - {hand_display}")
+            else:
                 from src.helpers.hand_judge import HandJudge
-                hand_eval = HandJudge.evaluate_hand(
-                    table.player_hole_cards[winner_idx],
-                    table.community_cards
-                )
-                print(f"  Player {winner_idx} ({table.players[winner_idx].__class__.__name__}): "
-                      f"{table.player_hole_cards[winner_idx]} - {hand_eval[0].replace('_', ' ').title()}")
+                for winner_idx in result['winners'].keys():
+                    hand_eval = HandJudge.evaluate_hand(
+                        table.player_hole_cards[winner_idx],
+                        table.community_cards
+                    )
+                    print(f"  Player {winner_idx} ({table.players[winner_idx].__class__.__name__}): "
+                          f"{table.player_hole_cards[winner_idx]} - {hand_eval[0].replace('_', ' ').title()}")
         elif result['ended_early']:
             print(f"\n--- Hand ended after {result['final_street']} (all but one folded) ---")
             

--- a/src/core/data_classes.py
+++ b/src/core/data_classes.py
@@ -85,3 +85,18 @@ class Action:
             action_type=data["action_type"],
             amount=data["amount"]
         )
+
+
+@dataclass
+class StreetHistory:
+    """Per-street action history with community cards on the board.
+
+    Attributes:
+        community_cards: Community cards on the board during this street (0-5 cards).
+        actions: List of actions taken on this street.
+    """
+    community_cards: List[str]
+    actions: List[Action]
+
+    def __repr__(self) -> str:
+        return f"StreetHistory(community_cards={self.community_cards}, actions={len(self.actions)} items)"

--- a/src/core/gamestate.py
+++ b/src/core/gamestate.py
@@ -2,7 +2,7 @@
 
 from typing import List, Dict, Tuple
 from copy import deepcopy
-from .data_classes import PlayerPublicInfo, Pot, Action
+from .data_classes import PlayerPublicInfo, Pot, Action, StreetHistory
 
 
 class PublicGamestate:
@@ -22,8 +22,8 @@ class PublicGamestate:
         blinds: Current (small_blind, big_blind) amounts
         blinds_schedule: Schedule of blind increases
         minimum_raise_amount: Minimum valid raise amount
-        current_hand_history: Actions taken in current hand by street
-        previous_hand_histories: History from previous hands
+        current_hand_history: Actions taken in current hand by street (Dict[str, StreetHistory])
+        previous_hand_histories: History from previous hands (list of Dict[str, StreetHistory])
     """
 
     def __init__(
@@ -37,8 +37,8 @@ class PublicGamestate:
         blinds: Tuple[int, int],
         blinds_schedule: Dict[int, Tuple[int, int]],
         minimum_raise_amount: int,
-        current_hand_history: Dict[str, List[Action]],
-        previous_hand_histories: List[Dict[str, List[Action]]]
+        current_hand_history: Dict[str, StreetHistory],
+        previous_hand_histories: List[Dict[str, StreetHistory]]
     ):
         """Initialize public gamestate
 
@@ -52,8 +52,8 @@ class PublicGamestate:
             blinds: Current blinds tuple
             blinds_schedule: Dictionary mapping round to blinds
             minimum_raise_amount: Minimum raise amount
-            current_hand_history: Current hand history by street
-            previous_hand_histories: Previous hands' histories
+            current_hand_history: Current hand history by street (StreetHistory per street)
+            previous_hand_histories: Previous hands' histories (each a Dict[str, StreetHistory])
         """
         self.round_number = round_number
         self.player_public_infos = player_public_infos

--- a/src/core/table.py
+++ b/src/core/table.py
@@ -622,6 +622,7 @@ class Table:
             - total_pot: Final pot size
             - ended_early: Whether hand ended before river
             - showdown: Whether hand went to showdown
+            - showdown_details: When showdown is True, dict with 'players' and 'hands'; otherwise None
         """
         # Initialize hand
         self.reset_hand_state()
@@ -645,6 +646,7 @@ class Table:
                 "total_pot": sum(w[1] for w in winners.values()),
                 "ended_early": ended_early,
                 "showdown": showdown,
+                "showdown_details": None,
                 "final_street": "preflop"
             }
 
@@ -662,6 +664,7 @@ class Table:
                 "total_pot": sum(w[1] for w in winners.values()),
                 "ended_early": ended_early,
                 "showdown": showdown,
+                "showdown_details": None,
                 "final_street": "flop"
             }
 
@@ -679,6 +682,7 @@ class Table:
                 "total_pot": sum(w[1] for w in winners.values()),
                 "ended_early": ended_early,
                 "showdown": showdown,
+                "showdown_details": None,
                 "final_street": "turn"
             }
 
@@ -692,12 +696,26 @@ class Table:
         eliminated = self.check_eliminations()
         self._finalize_hand()
 
+        if showdown:
+            active_players = [
+                i for i, info in enumerate(self.player_public_infos) if info.active
+            ]
+            hands = {}
+            for idx in active_players:
+                hole = self.player_hole_cards[idx]
+                if hole is not None and self.community_cards:
+                    hands[idx] = HandJudge.evaluate_hand(hole, self.community_cards)[0]
+            showdown_details = {"players": active_players, "hands": hands}
+        else:
+            showdown_details = None
+
         return {
             "winners": winners,
             "eliminated": eliminated,
             "total_pot": sum(w[1] for w in winners.values()),
             "ended_early": ended_early,
             "showdown": showdown,
+            "showdown_details": showdown_details,
             "final_street": "river"
         }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -250,12 +250,15 @@ def test_chip_distribution():
     table.community_cards = ['2s', '3c', '4h', '6d', '8s']  # No straight, pairs win
 
     # Add action history
-    from src.core.data_classes import Action
-    table.current_hand_history["preflop"] = [
-        Action(2, "all-in", 100),
-        Action(1, "all-in", 200),
-        Action(0, "bet", 200)
-    ]
+    from src.core.data_classes import Action, StreetHistory
+    table.current_hand_history["preflop"] = StreetHistory(
+        community_cards=[],
+        actions=[
+            Action(2, "all-in", 100),
+            Action(1, "all-in", 200),
+            Action(0, "bet", 200)
+        ]
+    )
 
     # Manually create pots
     from src.core.data_classes import Pot
@@ -320,11 +323,14 @@ def test_chip_distribution():
     initial_total = sum(p.stack for p in table.player_public_infos) + table.total_pot
 
     # Add hand history
-    from src.core.data_classes import Action
-    table.current_hand_history["preflop"] = [
-        Action(0, "bet", 100),
-        Action(1, "call", 100)
-    ]
+    from src.core.data_classes import Action, StreetHistory
+    table.current_hand_history["preflop"] = StreetHistory(
+        community_cards=[],
+        actions=[
+            Action(0, "bet", 100),
+            Action(1, "call", 100)
+        ]
+    )
 
     results = table.end_hand()
 
@@ -404,13 +410,16 @@ def test_chip_distribution():
     table.community_cards = ['2s', '3c', '4h', '6d', '8s']  # No improvement, pairs win
 
     # Add action history
-    from src.core.data_classes import Action
-    table.current_hand_history["preflop"] = [
-        Action(3, "all-in", 100),
-        Action(2, "all-in", 200),
-        Action(1, "all-in", 300),
-        Action(0, "bet", 300)
-    ]
+    from src.core.data_classes import Action, StreetHistory
+    table.current_hand_history["preflop"] = StreetHistory(
+        community_cards=[],
+        actions=[
+            Action(3, "all-in", 100),
+            Action(2, "all-in", 200),
+            Action(1, "all-in", 300),
+            Action(0, "bet", 300)
+        ]
+    )
 
     # Manually create pots based on contributions
     from src.core.data_classes import Pot
@@ -503,13 +512,16 @@ def test_chip_distribution():
     table.community_cards = ['As', '7c', '6h', '5d', '3s']  # High card Ace for all
 
     # Add action history - everyone bets 100
-    from src.core.data_classes import Action
-    table.current_hand_history["preflop"] = [
-        Action(3, "all-in", 100),
-        Action(0, "bet", 100),
-        Action(1, "call", 100),
-        Action(2, "call", 100)
-    ]
+    from src.core.data_classes import Action, StreetHistory
+    table.current_hand_history["preflop"] = StreetHistory(
+        community_cards=[],
+        actions=[
+            Action(3, "all-in", 100),
+            Action(0, "bet", 100),
+            Action(1, "call", 100),
+            Action(2, "call", 100)
+        ]
+    )
 
     results = table.end_hand()
 
@@ -593,12 +605,15 @@ def test_chip_distribution():
     table.community_cards = ['2s', '3c', '4h', '6d', '8s']  # No improvement, pairs win
 
     # Add action history
-    from src.core.data_classes import Action
-    table.current_hand_history["preflop"] = [
-        Action(2, "all-in", 100),  # P2 all-in for 100
-        Action(1, "all-in", 200),  # P1 all-in for 200
-        Action(0, "bet", 200)      # P0 bets 200 to match
-    ]
+    from src.core.data_classes import Action, StreetHistory
+    table.current_hand_history["preflop"] = StreetHistory(
+        community_cards=[],
+        actions=[
+            Action(2, "all-in", 100),  # P2 all-in for 100
+            Action(1, "all-in", 200),  # P1 all-in for 200
+            Action(0, "bet", 200)      # P0 bets 200 to match
+        ]
+    )
 
     # Manually create pots
     from src.core.data_classes import Pot


### PR DESCRIPTION
## Summary
This PR adds per-street action history via a StreetHistory dataclass (community cards + actions per street) and a showdown_details dict on simulate_hand() when the hand goes to showdown.

## Changes
- Hand history is now stored per street using StreetHistory { community_cards, actions } instead of a plain list of actions
- simulate_hand() now returns an optional showdown_details dict when the hand reaches showdown

Closes #5 