### PR TITLE
feat: add showdown details to the hand history 

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ def get_action(
 | `blinds_schedule` | Dict[int, Tuple[int, int]] | Future blind levels |
 | `minimum_raise_amount` | int | Minimum valid raise size |
 | `current_hand_history` | Dict[str, StreetHistory] | Per-street history: each value has `community_cards` and `actions` |
-| `previous_hand_histories` | List[Dict[str, StreetHistory]] | Past hand histories (same shape) |
+| `previous_hand_histories` | List[HandRecord] | Past hands: each HandRecord has `per_street` (Dict[str, StreetHistory]) and `showdown_details` (optional dict with 'players' and 'hands') |
 
 **Utility Methods:**
 - `get_current_street()`: Returns 'preflop', 'flop', 'turn', or 'river'
@@ -536,7 +536,7 @@ Players implement the `Player` interface, allowing different bot strategies to b
 - **Antes:** Modify `collect_blinds()` to collect antes
 - **Different Poker Variants:** Extend `HandJudge` with new hand rankings
 - **Tournament Payouts:** Add payout structure to Table
-- **Hand Logging:** Hand history is already per-street (`StreetHistory` with `community_cards` and `actions`); extend as needed
+- **Hand Logging:** Hand history is per-street (`StreetHistory`) and stored as `HandRecord` (per_street + optional `showdown_details` when hand goes to showdown); extend as needed
 - **Real-time Visualization:** Hook into betting round callbacks
 
 ## File Structure

--- a/src/core/data_classes.py
+++ b/src/core/data_classes.py
@@ -1,7 +1,7 @@
 """Core data classes for poker game state"""
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Dict, Optional
 
 
 @dataclass
@@ -100,3 +100,15 @@ class StreetHistory:
 
     def __repr__(self) -> str:
         return f"StreetHistory(community_cards={self.community_cards}, actions={len(self.actions)} items)"
+
+
+@dataclass
+class HandRecord:
+    """One hand's stored history: per-street actions and optional showdown.
+
+    Attributes:
+        per_street: Action history by street (preflop, flop, turn, river).
+        showdown_details: When hand went to showdown, dict with 'players' and 'hands'; otherwise None.
+    """
+    per_street: Dict[str, StreetHistory]
+    showdown_details: Optional[dict]

--- a/src/core/gamestate.py
+++ b/src/core/gamestate.py
@@ -2,7 +2,7 @@
 
 from typing import List, Dict, Tuple
 from copy import deepcopy
-from .data_classes import PlayerPublicInfo, Pot, Action, StreetHistory
+from .data_classes import PlayerPublicInfo, Pot, Action, StreetHistory, HandRecord
 
 
 class PublicGamestate:
@@ -23,7 +23,7 @@ class PublicGamestate:
         blinds_schedule: Schedule of blind increases
         minimum_raise_amount: Minimum valid raise amount
         current_hand_history: Actions taken in current hand by street (Dict[str, StreetHistory])
-        previous_hand_histories: History from previous hands (list of Dict[str, StreetHistory])
+        previous_hand_histories: History from previous hands (list of HandRecord: per_street + optional showdown_details)
     """
 
     def __init__(
@@ -38,7 +38,7 @@ class PublicGamestate:
         blinds_schedule: Dict[int, Tuple[int, int]],
         minimum_raise_amount: int,
         current_hand_history: Dict[str, StreetHistory],
-        previous_hand_histories: List[Dict[str, StreetHistory]]
+        previous_hand_histories: List[HandRecord]
     ):
         """Initialize public gamestate
 
@@ -53,7 +53,7 @@ class PublicGamestate:
             blinds_schedule: Dictionary mapping round to blinds
             minimum_raise_amount: Minimum raise amount
             current_hand_history: Current hand history by street (StreetHistory per street)
-            previous_hand_histories: Previous hands' histories (each a Dict[str, StreetHistory])
+            previous_hand_histories: Previous hands' histories (each a HandRecord with per_street and showdown_details)
         """
         self.round_number = round_number
         self.player_public_infos = player_public_infos


### PR DESCRIPTION
## Summary
Hand history now stores optional showdown details and is saved at the end of each hand so players can see who had what when reviewing past hands (e.g. to spot bluffs).

## Changes
- Added HandRecord data class with per_street and showdown_details (optional)
- Hand is now saved at the end of the current hand