### PR TITLE
feat: add hole cards to showdown details

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ This is a complete No-Limit Texas Hold'em tournament simulator designed for AI b
 
 | Method | Purpose |
 |--------|---------|
-| `simulate_hand()` | Orchestrates a complete hand from deal to showdown; returns dict with `winners`, `eliminated`, `total_pot`, `ended_early`, `showdown` (bool), `final_street`, and when showdown is True, `showdown_details` (dict with `players` and `hands`) |
+| `simulate_hand()` | Orchestrates a complete hand from deal to showdown; returns dict with `winners`, `eliminated`, `total_pot`, `ended_early`, `showdown` (bool), `final_street`, and when showdown is True, `showdown_details` (dict with `players`, `hands`, and `hole_cards`) |
 | `run_betting_round(street)` | Executes betting logic for a single street |
 | `_reconcile_bets_to_pots()` | Creates side pots for all-in scenarios |
 | `end_hand()` | Evaluates hands and distributes winnings |
@@ -137,7 +137,7 @@ def get_action(
 | `blinds_schedule` | Dict[int, Tuple[int, int]] | Future blind levels |
 | `minimum_raise_amount` | int | Minimum valid raise size |
 | `current_hand_history` | Dict[str, StreetHistory] | Per-street history: each value has `community_cards` and `actions` |
-| `previous_hand_histories` | List[HandRecord] | Past hands: each HandRecord has `per_street` (Dict[str, StreetHistory]) and `showdown_details` (optional dict with 'players' and 'hands') |
+| `previous_hand_histories` | List[HandRecord] | Past hands: each HandRecord has `per_street` (Dict[str, StreetHistory]) and `showdown_details` (optional dict with 'players', 'hands', and 'hole_cards') |
 
 **Utility Methods:**
 - `get_current_street()`: Returns 'preflop', 'flop', 'turn', or 'river'

--- a/src/core/data_classes.py
+++ b/src/core/data_classes.py
@@ -108,7 +108,7 @@ class HandRecord:
 
     Attributes:
         per_street: Action history by street (preflop, flop, turn, river).
-        showdown_details: When hand went to showdown, dict with 'players' and 'hands'; otherwise None.
+        showdown_details: When hand went to showdown, dict with 'players', 'hands', and 'hole_cards'; otherwise None.
     """
     per_street: Dict[str, StreetHistory]
     showdown_details: Optional[dict]

--- a/src/core/table.py
+++ b/src/core/table.py
@@ -626,7 +626,7 @@ class Table:
             - total_pot: Final pot size
             - ended_early: Whether hand ended before river
             - showdown: Whether hand went to showdown
-            - showdown_details: When showdown is True, dict with 'players' and 'hands'; otherwise None
+            - showdown_details: When showdown is True, dict with 'players', 'hands', and 'hole_cards' (player_idx -> (card, card)); otherwise None
         """
         # Initialize hand
         self.reset_hand_state()
@@ -708,11 +708,14 @@ class Table:
                 i for i, info in enumerate(self.player_public_infos) if info.active
             ]
             hands = {}
+            hole_cards: Dict[int, Tuple[str, str]] = {}
             for idx in active_players:
                 hole = self.player_hole_cards[idx]
-                if hole is not None and self.community_cards:
-                    hands[idx] = HandJudge.evaluate_hand(hole, self.community_cards)[0]
-            showdown_details = {"players": active_players, "hands": hands}
+                if hole is not None:
+                    hole_cards[idx] = hole
+                    if self.community_cards:
+                        hands[idx] = HandJudge.evaluate_hand(hole, self.community_cards)[0]
+            showdown_details = {"players": active_players, "hands": hands, "hole_cards": hole_cards}
         else:
             showdown_details = None
 


### PR DESCRIPTION
## Summary
Showdown details now include each player's actual hole cards so you can see exactly what they had when reviewing past hands.

## Changes
- Added hole_cards to showdown_details
- Updated docs to describe hole_cards